### PR TITLE
Fix for crash with Litematica

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.10.0+build.208
 
 # Mod Properties
-	mod_version = 2.2.9
+	mod_version = 2.2.9-litematicafix
 	maven_group = io.github.kvverti
 	archives_base_name = colormatic
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.10.0+build.208
 
 # Mod Properties
-	mod_version = 2.2.8
+	mod_version = 2.2.9
 	maven_group = io.github.kvverti
 	archives_base_name = colormatic
 

--- a/src/main/java/io/github/kvverti/colormatic/colormap/BiomeColormap.java
+++ b/src/main/java/io/github/kvverti/colormatic/colormap/BiomeColormap.java
@@ -140,12 +140,18 @@ public class BiomeColormap implements ColormaticResolver {
     /**
      * Retrieves the biome coloring for the given block position, taking into
      * account the client's biome blend options If either `world` or `pos` is
-     * null, this returns the colormap's default color.
+     * null, this returns the colormap's default color. Also returns 
+     * colormap's default color if the wrong BlockRenderView type is passed.
      */
     public static int getBiomeColor(BlockRenderView world, BlockPos pos, BiomeColormap colormap) {
         if(world == null || pos == null) {
             return colormap.getDefaultColor();
         }
-        return ((ColormaticBlockRenderView)world).colormatic_getColor(pos, colormap);
+        try {
+            return ((ColormaticBlockRenderView)world).colormatic_getColor(pos, colormap);
+        }
+        catch(Exception e) {
+            return colormap.getDefaultColor();
+        }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,14 +4,14 @@
   "version": "${version}",
 
   "name": "Colormatic",
-  "description": "Adds the ability to customize colors hardcoded in vanilla.",
+  "description": "Adds the ability to customize colors hardcoded in vanilla. Contains fix for a crash with Litematica",
   "authors": [
     "kwerti"
   ],
   "contact": {
     "homepage": "https://github.com/kvverti/colormatic",
     "issues": "https://github.com/kvverti/colormatic/issues",
-    "sources": "https://github.com/kvverti/colormatic"
+    "sources": "https://github.com/helpimnotdrowning/colormatic"
   },
 
   "license": "LGPL-3",


### PR DESCRIPTION
Litematica sends over a different type to getBiomeColor() when rendering anything using biome colors (water, leaves), so if it fails (when Litematica uses ChunkCacheSchematic type instead of ColormaticBlockRenderView), it uses the default color.

Fixes #29 , maruohon/litematica#310