### PR TITLE
Add support for Sodium 1.18.1-alpha6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 		transitive = false
 	}
 	modCompileOnly "maven.modrinth:sodium:${project.sodium_version}"
-//	modRuntime "maven.modrinth:sodium:${project.sodium_version}"
+	//modRuntime "maven.modrinth:sodium:${project.sodium_version}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.8
 
 # Mod Properties
-	mod_version = 3.0.0
+	mod_version = 3.0.1
 	maven_group = io.github.kvverti
 	archives_base_name = colormatic
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ org.gradle.jvmargs=-Xmx1G
 	fabric_version=0.43.1+1.18
 	mod_menu_version=3.0.0
 	cloth_config_version=6.0.39
-	sodium_version=mc1.17.1-0.3.0
+	sodium_version=mc1.18.1-0.4.0-alpha6

--- a/src/main/java/io/github/kvverti/colormatic/mixinsodium/color/SodiumBlockColorsMixin.java
+++ b/src/main/java/io/github/kvverti/colormatic/mixinsodium/color/SodiumBlockColorsMixin.java
@@ -22,7 +22,7 @@
 package io.github.kvverti.colormatic.mixinsodium.color;
 
 import io.github.kvverti.colormatic.colormap.BiomeColormaps;
-import me.jellysquid.mods.sodium.client.model.quad.ModelQuadColorProvider;
+import me.jellysquid.mods.sodium.client.model.quad.blender.ColorSampler;
 import me.jellysquid.mods.sodium.client.world.biome.BlockColorsExtended;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
@@ -38,14 +38,14 @@ import net.minecraft.client.color.block.BlockColors;
 public abstract class SodiumBlockColorsMixin implements BlockColorsExtended {
 
     @Unique
-    private static final ModelQuadColorProvider<BlockState> COLORMATIC_PROVIDER =
+    private static final ColorSampler<BlockState> COLORMATIC_PROVIDER =
         (state, world, pos, tintIndex) -> BiomeColormaps.getBiomeColor(state, world, pos);
 
     /**
      * Displace Sodium's implementation to first check Colormatic's custom block colors.
      */
     @Intrinsic(displace = true)
-    public ModelQuadColorProvider<BlockState> i$getColorProvider(BlockState state) {
+    public ColorSampler<BlockState> i$getColorProvider(BlockState state) {
         if(BiomeColormaps.isCustomColored(state)) {
             return COLORMATIC_PROVIDER;
         }

--- a/src/main/java/io/github/kvverti/colormatic/mixinsodium/world/SodiumBiomeAccessAccessor.java
+++ b/src/main/java/io/github/kvverti/colormatic/mixinsodium/world/SodiumBiomeAccessAccessor.java
@@ -1,0 +1,11 @@
+package io.github.kvverti.colormatic.mixinsodium.world;
+
+import net.minecraft.world.biome.source.BiomeAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(BiomeAccess.class)
+public interface SodiumBiomeAccessAccessor {
+    @Accessor
+    public long getSeed();
+}

--- a/src/main/java/io/github/kvverti/colormatic/mixinsodium/world/SodiumClientWorldMixin.java
+++ b/src/main/java/io/github/kvverti/colormatic/mixinsodium/world/SodiumClientWorldMixin.java
@@ -1,0 +1,16 @@
+package io.github.kvverti.colormatic.mixinsodium.world;
+
+import me.jellysquid.mods.sodium.client.world.BiomeSeedProvider;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+
+// This for some reason fixes the whole Sodium BiomeSeedProvider issue
+@Mixin(value = ClientWorld.class, priority = 2039)
+public class SodiumClientWorldMixin implements BiomeSeedProvider {
+
+    @Override
+    public long getBiomeSeed() {
+        return ((SodiumBiomeAccessAccessor) ((World) (Object) this).getBiomeAccess()).getSeed();
+    }
+}

--- a/src/main/resources/colormatic.sodium.mixins.json
+++ b/src/main/resources/colormatic.sodium.mixins.json
@@ -5,7 +5,9 @@
   "plugin": "io.github.kvverti.colormatic.mixinsodium.SodiumMixinFilterPlugin",
   "client": [
     "color.SodiumBlockColorsMixin",
-    "color.SodiumItemColorsMixin"
+    "color.SodiumItemColorsMixin",
+    "world.SodiumClientWorldMixin",
+    "world.SodiumBiomeAccessAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This adds support for Sodium 1.18.1-alpha6, closing #74. However, there are a couple of new mixins in this code to get Sodium to work, that are supposed to be redundant but were for some reason needed in order for the world to actually load without crashing.

Feel free to just use this PR as a reference.

Edit: Upon further inspection, it appears that due to Colormatic disabling `features.fast_biome_colors` in Sodium, the [MixinColorWorld](https://github.com/CaffeineMC/sodium-fabric/blob/1.18.x/dev/src/main/java/me/jellysquid/mods/sodium/mixin/features/fast_biome_colors/MixinClientWorld.java) mixin feature never gets registered, thus causing a crash from Sodium casting ClientWorld to BiomeSeedProvider.