### PR TITLE
Write translators as contributors

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -6,7 +6,9 @@
   "name": "Colormatic",
   "description": "Adds the ability to customize colors hardcoded in vanilla.",
   "authors": [
-    "kwerti",
+    "kwerti"
+  ],
+  "contributors": [
     "Hambaka (Chinese Simplified localization)",
     "Madis0 (Estonian localization)"
   ],


### PR DESCRIPTION
When writing translators as authors, all names after the first are usually cut due to screen size constraints. When writing them as contributors, however, they are listed on separate lines.