### PR TITLE
Less specific Mod Menu recommendation

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,7 +40,7 @@
   },
   "recommends": {
     "quilt_loader": "*",
-    "modmenu": "^3.0.0"
+    "modmenu": "*"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION
Your current Mod Menu recommendation is not compatible with the latest Mod Menu (4.0.0), so why make it so specific at all?