### PR TITLE
Proposal for fix of #6

### DIFF
--- a/src/main/java/io/github/kvverti/colormatic/Lightmaps.java
+++ b/src/main/java/io/github/kvverti/colormatic/Lightmaps.java
@@ -34,7 +34,9 @@ import net.minecraft.world.World;
  */
 public final class Lightmaps {
 
-    private static final Map<Identifier, Lightmap> lightmaps = new HashMap<>();
+    private static final Map<Identifier, Lightmap> lightmaps = new HashMap<>(3);
+
+    private static boolean worldRenderFinished = true;
 
     public static Lightmap get(World world) {
         return lightmaps.get(Colormatic.getDimId(world));
@@ -47,4 +49,12 @@ public final class Lightmaps {
     public static void clearLightmaps() {
         lightmaps.clear();
     }
+
+	public static boolean isWorldRenderFinished() {
+		return worldRenderFinished;
+	}
+
+	public static void setWorldRenderFinished(final boolean worldRenderFinished) {
+		Lightmaps.worldRenderFinished = worldRenderFinished;
+	}
 }

--- a/src/main/java/io/github/kvverti/colormatic/mixin/render/GameRendererMixin.java
+++ b/src/main/java/io/github/kvverti/colormatic/mixin/render/GameRendererMixin.java
@@ -1,0 +1,48 @@
+package io.github.kvverti.colormatic.mixin.render;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import io.github.kvverti.colormatic.Lightmaps;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.util.math.MatrixStack;
+
+/***
+ * 
+ * @author Velnias75
+ *
+ */
+@Mixin(GameRenderer.class)
+public abstract class GameRendererMixin {
+
+	@Shadow
+	@Final
+	private MinecraftClient client;
+
+	@Shadow
+	@Final
+	private LightmapTextureManager lightmapTextureManager;
+
+	@Inject(method = "renderWorld", at = @At("INVOKE"))
+	private void onRenderWorldHead(final CallbackInfo info) {
+		Lightmaps.setWorldRenderFinished(false);
+	}
+
+	@Inject(method = "renderWorld", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILHARD)
+	private void onRenderWorldReturn(float tickDelta, long limitTime, MatrixStack matrices, final CallbackInfo info) {
+
+		Lightmaps.setWorldRenderFinished(true);
+
+		if (Lightmaps.get(client.world) != null) {
+			lightmapTextureManager.update(tickDelta);
+			lightmapTextureManager.tick();
+		}
+	}
+}

--- a/src/main/resources/colormatic.mixins.json
+++ b/src/main/resources/colormatic.mixins.json
@@ -35,6 +35,7 @@
     "render.ItemRendererMixin",
     "render.LightmapTextureManagerMixin",
     "render.WorldRendererMixin",
+    "render.GameRendererMixin",
     "text.AbstractButtonWidgetMixin",
     "text.ChatFormatMixin",
     "text.DyeColorMixin",


### PR DESCRIPTION
Hi,

I got the GUI to display in correct colors. But I don't fully understand your (or Minecraft's) flickering code.

Essentially it applies the custom lighting only to the *world render* phase and applies afterwards *Minecraft's* own lighting.


To test, you can use this tiny test resourcepack: [lightmap-bug.zip](https://github.com/kvverti/colormatic/files/10691653/lightmap-bug.zip)

Go into the *Nether*:

* Without my PR all GUI (inventory, texts, etc.)  will get yellowish and will stay even after returning to the main menu.
* With my PR the custom lightmap gets applied, but all GUI including the main menu stay in correct colors.

